### PR TITLE
docker container error

### DIFF
--- a/error
+++ b/error
@@ -1,0 +1,55 @@
+Wind River Linux 9.0.0.20 qemux86-64 console
+
+qemux86-64 login: cp: cannot stat '/home/pfe/junos/loader.conf': No such file or directory
+mkfs.fat 4.0 (2016-05-06)
+Total number of sectors (32768) not a multiple of sectors per track (63)!
+Add mtools_skip_check=1 to your .mtoolsrc file to skip this test
+image: /home/pfe/junos/metadata-usb.img
+file format: qcow2
+virtual size: 16M (16777216 bytes)
+disk size: 328K
+cluster_size: 65536
+Format specific information:
+    compat: 1.1
+    lazy refcounts: false
+    refcount bits: 16
+    corrupt: false
+INIT: Sending p[   17.017588] br-ext: port 1(eth0) entered disabled state
+851
+[   17.093177] IPv6: ADDRCONF(NETDEV_UP): br-ext: link is not ready
+[   17.103454] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
+[   17.107790] br-ext: port 1(eth0) entered blocking state
+[   17.112330] br-ext: port 1(eth0) entered forwarding state
+[   17.117095] IPv6: ADDRCONF(NETDEV_CHANGE): br-ext: link becomes ready
+Product is VM-vcp_vmx1-161-re-0
+VCPMEM in MB: 2048, VCPCPU: 2
+trace command not available: missing audit-libs devel package at build time.
+[   17.315104] br-ext: port 2(tap0) entered blocking state
+[   17.318482] br-ext: port 2(tap0) entered disabled state
+[   17.323850] device tap0 entered promiscuous mode
+[   17.327229] br-ext: port 2(tap0) entered blocking state
+[   17.330021] br-ext: port 2(tap0) entered forwarding state
+[   17.336812] int: port 1(tap1) entered blocking state
+[   17.341406] int: port 1(tap1) entered disabled state
+[   17.346619] device tap1 entered promiscuous mode
+[   17.351374] int: port 1(tap1) entered blocking state
+[   17.356131] int: port 1(tap1) entered forwarding state
+[   17.387825] kvm: SMP vm created on host with unstable TSC; guest TSC will not be reliable
+qemu-system-x86_64: cannot set up guest memory 'pc.ram': Cannot allocate memory
+[   17.402036] int: port 1(tap1) entered disabled state
+[   17.405290] device tap1 left promiscuous mode
+[   17.407992] int: port 1(tap1) entered disabled state
+[   17.415324] br-ext: port 2(tap0) entered disabled state
+[   17.419941] device tap0 left promiscuous mode
+[   17.423233] br-ext: port 2(tap0) entered disabled state
+nc: can't connect to remote host (127.0.0.1): Connection refused
+nc: can't connect to remote host (127.0.0.1): Connection refused
+
+[   18.079881] br-ext: port 1(eth0) entered disabled state
+nc: can't connect to remote host (127.0.0.1): Connection refused
+nc: can't connect to remote host (127.0.0.1): Connection refused
+mount /dev/hda1 /boot 
+[   19.104192] e1000: eth0 NIC Link is Up 1000 Mbps Full Duplex, Flow Control: RX
+[   19.114690] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   19.122226] br-ext: port 1(eth0) entered blocking state
+[   19.124992] br-ext: port 1(eth0) entered forwarding state


### PR DESCRIPTION
Wind River Linux 9.0.0.20 qemux86-64 console

qemux86-64 login: cp: cannot stat '/home/pfe/junos/loader.conf': No such file or directory
mkfs.fat 4.0 (2016-05-06)
Total number of sectors (32768) not a multiple of sectors per track (63)!
Add mtools_skip_check=1 to your .mtoolsrc file to skip this test
image: /home/pfe/junos/metadata-usb.img
file format: qcow2
virtual size: 16M (16777216 bytes)
disk size: 328K
cluster_size: 65536
Format specific information:
    compat: 1.1
    lazy refcounts: false
    refcount bits: 16
    corrupt: false
INIT: Sending processes the TERM signal
[   22.416802] br-ext: port 1(eth0) entered disabled state
851
[   22.491639] IPv6: ADDRCONF(NETDEV_UP): br-ext: link is not ready
[   22.502218] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
[   22.504166] br-ext: port 1(eth0) entered blocking state
[   22.505993] br-ext: port 1(eth0) entered forwarding state
[   22.507816] IPv6: ADDRCONF(NETDEV_CHANGE): br-ext: link becomes ready
Product is VM-vcp_vmx1-161-re-0
VCPMEM in MB: 2048, VCPCPU: 2
trace command not available: missing audit-libs devel package at build time.
[   22.723745] br-ext: port 2(tap0) entered blocking state
[   22.725955] br-ext: port 2(tap0) entered disabled state
[   22.730424] device tap0 entered promiscuous mode
[   22.732642] br-ext: port 2(tap0) entered blocking state
[   22.735027] br-ext: port 2(tap0) entered forwarding state
[   22.738719] int: port 1(tap1) entered blocking state
[   22.740520] int: port 1(tap1) entered disabled state
[   22.742402] device tap1 entered promiscuous mode
[   22.744263] int: port 1(tap1) entered blocking state
[   22.746117] int: port 1(tap1) entered forwarding state
[   22.756580] unchecked MSR access error: RDMSR from 0xc0000103 at rIP: 0xffffffff81060332 (native_read_msr+0x2/0x40)
[   22.759922]  ffffffffa017e375 ffff880079638000 0000000000000000 0000000000000000
[   22.762632]  ffff88007994cad8 ffff880079638000 ffffc90001e27da8 ffffffffa0056cb6
[   22.765398]  0000000000000000 ffff88007994c000 ffff880079638000 0000000000000000
[   22.768257] Call Trace:
[   22.769225]  [<ffffffffa017e375>] ? svm_vcpu_load+0x85/0x220 [kvm_amd]
[   22.771452]  [<ffffffffa0056cb6>] kvm_arch_vcpu_load+0x46/0x280 [kvm]
[   22.773616]  [<ffffffffa004036d>] vcpu_load+0x4d/0x80 [kvm]
[   22.775456]  [<ffffffffa005b92e>] kvm_arch_vcpu_setup+0x1e/0x50 [kvm]
[   22.777600]  [<ffffffffa0044bfc>] kvm_vm_ioctl+0x2cc/0x730 [kvm]
[   22.779592]  [<ffffffff81a52c15>] ? __schedule+0x1c5/0x6c0
[   22.781462]  [<ffffffff81a57060>] ? __switch_to_asm+0x30/0x60
[   22.783354]  [<ffffffff81a57054>] ? __switch_to_asm+0x24/0x60
[   22.785354]  [<ffffffff81a57060>] ? __switch_to_asm+0x30/0x60
[   22.787318]  [<ffffffff81a57054>] ? __switch_to_asm+0x24/0x60
[   22.789306]  [<ffffffff81a57060>] ? __switch_to_asm+0x30/0x60
[   22.791198]  [<ffffffff811e9c77>] do_vfs_ioctl+0x97/0x5d0
[   22.793037]  [<ffffffff81a57060>] ? __switch_to_asm+0x30/0x60
[   22.794943]  [<ffffffff81a57054>] ? __switch_to_asm+0x24/0x60
[   22.796908]  [<ffffffff811f4aef>] ? __fget+0x7f/0xb0
[   22.798553]  [<ffffffff811ea229>] SyS_ioctl+0x79/0x90
[   22.800256]  [<ffffffff810906ae>] ? __task_pid_nr_ns+0x7e/0xd0
[   22.802213]  [<ffffffff81003ac8>] do_syscall_64+0x68/0xe0
[   22.804145]  [<ffffffff81a56f4e>] entry_SYSCALL_64_after_swapgs+0x58/0xc6
[   22.806430] unchecked MSR access error: WRMSR to 0xc0000103 (tried to write 0x0000000000000000) at rIP: 0xffffffff810603b4 (native_write_msr+0x4/0x30)
[   22.810758]  ffffffffa017c130 ffff880079638000 0000000000000000 ffffc90001e27db8
[   22.813535]  ffffffffa0056f10 ffff880079638000 ffffc90001e27dd0 ffffffffa00403ef
[   22.816335]  ffff880079638000 ffffc90001e27df0 ffffffffa005b94f 000000000000ae41
[   22.819173] Call Trace:
[   22.820128]  [<ffffffffa017c130>] ? svm_vcpu_put+0x90/0xc0 [kvm_amd]
[   22.822296]  [<ffffffffa0056f10>] kvm_arch_vcpu_put+0x20/0x50 [kvm]
[   22.824382]  [<ffffffffa00403ef>] vcpu_put+0x1f/0x60 [kvm]
[   22.826174]  [<ffffffffa005b94f>] kvm_arch_vcpu_setup+0x3f/0x50 [kvm]
[   22.828309]  [<ffffffffa0044bfc>] kvm_vm_ioctl+0x2cc/0x730 [kvm]
[   22.830352]  [<ffffffff81a52c15>] ? __schedule+0x1c5/0x6c0
[   22.832198]  [<ffffffff81a57060>] ? __switch_to_asm+0x30/0x60
[   22.834076]  [<ffffffff81a57054>] ? __switch_to_asm+0x24/0x60
[   22.836071]  [<ffffffff81a57060>] ? __switch_to_asm+0x30/0x60
[   22.838052]  [<ffffffff81a57054>] ? __switch_to_asm+0x24/0x60
[   22.840034]  [<ffffffff81a57060>] ? __switch_to_asm+0x30/0x60
[   22.841925]  [<ffffffff811e9c77>] do_vfs_ioctl+0x97/0x5d0
[   22.843774]  [<ffffffff81a57060>] ? __switch_to_asm+0x30/0x60
[   22.845726]  [<ffffffff81a57054>] ? __switch_to_asm+0x24/0x60
[   22.847737]  [<ffffffff811f4aef>] ? __fget+0x7f/0xb0
[   22.849546]  [<ffffffff811ea229>] SyS_ioctl+0x79/0x90
[   22.851381]  [<ffffffff810906ae>] ? __task_pid_nr_ns+0x7e/0xd0
[   22.853462]  [<ffffffff81003ac8>] do_syscall_64+0x68/0xe0
[   22.855567]  [<ffffffff81a56f4e>] entry_SYSCALL_64_after_swapgs+0x58/0xc6
[   22.859984] kvm: SMP vm created on host with unstable TSC; guest TSC will not be reliable
qemu-system-x86_64: cannot set up guest memory 'pc.ram': Cannot allocate memory
[   22.865335] int: port 1(tap1) entered disabled state
[   22.867395] device tap1 left promiscuous mode
[   22.869288] int: port 1(tap1) entered disabled state
[   22.876312] br-ext: port 2(tap0) entered disabled state
[   22.879245] device tap0 left promiscuous mode
[   22.880860] br-ext: port 2(tap0) entered disabled state
nc: can't connect to remote host (127.0.0.1): Connection refused
nc: can't connect to remote host (127.0.0.1): Connection refused

[   23.456951] br-ext: port 1(eth0) entered disabled state
nc: can't connect to remote host (127.0.0.1): Connection refused
nc: can't connect to remote host (127.0.0.1): Connection refused
mount /dev/hda1 /boot 
[   24.546883] e1000: eth0 NIC Link is Up 1000 Mbps Full Duplex, Flow Control: RX
[   24.551848] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[   24.558657] br-ext: port 1(eth0) entered blocking state
[   24.560367] br-ext: port 1(eth0) entered forwarding state
